### PR TITLE
feat: Add Dockerized local development environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# Use an Alpine image with glibc already installed: https://github.com/Docker-Hub-frolvlad/docker-alpine-glibc/tree/master
+FROM frolvlad/alpine-glibc:latest
+
+# Set Architecture Compatibility
+ARG GLIBC_ARCH=x86_64
+# ARG GLIBC_ARCH=aarch64
+
+# Mount /root vol for potential ssh keys or other user-specific configs
+VOLUME ["/root"]
+
+# Mount /data vol for project files
+VOLUME ["/data"]
+WORKDIR /data
+
+# Update and Install Dependencies
+RUN set -e \
+    && apk --no-cache update  \
+    && apk --no-cache add \
+        bash \
+        fish \
+        binutils \
+        bind-tools \
+        curl \
+        jq \
+        groff \
+        less \
+        ca-certificates \
+        openssl \
+        unzip \
+        wget \
+        git \
+        openssh-client \
+        py3-pip \
+        py3-dnspython \
+        py3-jmespath \
+        ansible \
+        ansible-lint \
+    && rm -rf /var/cache/apk/* /tmp/*
+
+# Default command to bash shell
+CMD [ "/bin/bash" ]

--- a/README.md
+++ b/README.md
@@ -54,9 +54,81 @@ The project structure is as follows:
 
 ## Pre-requisites
 
-In order to deploy the Ansible controller container, you need to install [Docker](https://www.docker.com/).
+To work with this project, you will need [Docker](https://www.docker.com/) installed. Modern Docker installations include `docker compose` (note the space, not a hyphen), which is used by this project.
 
-## Installation
+## Local Development Environment using Docker
+
+This project includes a Dockerized environment to provide a consistent and isolated space for Ansible development and execution. It simplifies setup and ensures all contributors use the same versions of Ansible and related tools.
+
+The old `ansible-ctrl.dockerfile` and associated `install.sh`/`install.ps1` scripts are still present but are superseded by the `Dockerfile` and `docker-compose.yml` for local development.
+
+### Setup and Usage
+
+1.  **Build the Docker Image:**
+    Open your terminal in the root of this project and run:
+    ```bash
+    sudo docker compose build
+    ```
+    This command builds the Docker image based on the `Dockerfile`. You only need to run this initially or when the `Dockerfile` changes. Adding `--no-cache` is recommended if you suspect caching issues or want a fresh build.
+
+2.  **Start the Development Container:**
+    To start the container in the background (detached mode):
+    ```bash
+    sudo docker compose up -d
+    ```
+    Your project directory is mounted into `/data` inside the container.
+
+3.  **Accessing the Container Shell:**
+    To get an interactive shell (bash by default) inside the running container:
+    ```bash
+    sudo docker compose exec ansible-dev bash
+    ```
+    You can also use `fish` if you prefer:
+    ```bash
+    sudo docker compose exec ansible-dev fish
+    ```
+
+4.  **Running Ansible Commands:**
+    Once inside the container's shell, you can run Ansible commands as usual. The working directory will be `/data`, which is your project root.
+    ```bash
+    # Example: Lint a playbook
+    ansible-lint deploy.yml
+
+    # Example: Run a playbook (ensure your inventory is set up and SSH_PASSWORD etc. are exported if needed)
+    # export SSH_PASSWORD="your_ssh_password"
+    ansible-playbook -i inventories/workstations/hosts.yml deploy.yml
+    ```
+    Alternatively, you can run commands directly without entering the shell:
+    ```bash
+    sudo docker compose exec ansible-dev ansible-lint deploy.yml
+    sudo docker compose exec ansible-dev ansible-playbook -i inventories/workstations/hosts.yml deploy.yml
+    ```
+
+5.  **Volume Mounts:**
+    The `docker-compose.yml` file configures the following important volume mounts:
+    *   `.:/data`: Your entire project directory is mapped to `/data` in the container. Changes made locally are reflected inside the container, and vice-versa.
+    *   `~/.ssh:/root/.ssh:ro`: Your local SSH keys (from `~/.ssh`) are mounted read-only into the container. This allows Ansible running inside the container to connect to your managed nodes.
+    *   `~/.gitconfig:/root/.gitconfig:ro`: Your local Git configuration is mounted read-only.
+
+6.  **Internet Connectivity Check:**
+    Playbooks that include roles known to require internet access (like `arch-iso-install` or `network` for package installation) have a pre-flight check. This check attempts to connect to `google.com`. If it fails, the playbook will halt before running internet-dependent tasks. This is to ensure a better experience when working offline or with intermittent connectivity.
+
+7.  **Stopping the Container:**
+    When you're done, you can stop the container:
+    ```bash
+    sudo docker compose down
+    ```
+    If you just want to stop it without removing it (so it starts faster next time):
+    ```bash
+    sudo docker compose stop
+    ```
+
+### Offline Usage
+Once the Docker image is built (`docker compose build`), the Ansible tools (Ansible, Ansible Lint, Git, etc.) are installed within the image. This means you can use these tools inside the container to work on your playbooks (e.g., editing, linting, running playbooks against locally accessible hosts or VMs) without an active internet connection.
+
+However, any Ansible tasks that inherently require internet access (e.g., downloading packages with `apt`/`yum`/`pacman`, cloning git repositories from the internet, using `uri` to fetch remote files) will naturally fail if the container cannot access the internet. The pre-flight internet check mentioned above aims to catch this early for known roles.
+
+## Original Installation (Legacy - for reference if needed)
 
 1. Ensure your processor architecture `ARG GLIBC_ARCH` is set in `ansible-ctrl.dockerfile`.
 2. Run the appropriate script based on your operating system:
@@ -65,6 +137,7 @@ In order to deploy the Ansible controller container, you need to install [Docker
     - Win: `powershell .\install.ps1`
 
 3. Connect to your docker: `docker exec -it $(docker ps -f name=ansible-ctrl -q) fish`
+
 
 ## Host Initialization
 

--- a/deploy.yml
+++ b/deploy.yml
@@ -5,6 +5,22 @@
 
 - hosts: virtual_hosts
   become: true
+  pre_tasks:
+    - name: Check for internet connectivity
+      ansible.builtin.uri:
+        url: "https://www.google.com"
+        method: HEAD
+        timeout: 5
+      register: internet_check
+      ignore_errors: true
+
+    - name: Fail if no internet connection and internet-dependent roles are to be run
+      ansible.builtin.fail:
+        msg: "Internet connection is required but not available. Checked by trying to reach google.com."
+      when:
+        - internet_check.status == -1 or internet_check.status >= 400
+        # Add conditions here if specific roles/tags requiring internet are targeted
+        # For now, this play (virtual_hosts) implies internet is needed due to its roles.
   roles:
     - role: arch-iso-install
       when: ansible_nodename == 'archiso'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,42 @@
+version: '3.8'
+
+services:
+  ansible-dev:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        # You can specify GLIBC_ARCH if building on a different architecture, e.g., aarch64
+        # GLIBC_ARCH: aarch64
+        GLIBC_ARCH: x86_64
+    volumes:
+      # Mount the current project directory to /data in the container
+      - .:/data
+      # Mount user's SSH keys for Ansible to connect to managed nodes
+      # Important: This assumes your SSH keys are in the default ~/.ssh location
+      # Adjust the host path if your keys are elsewhere.
+      - ~/.ssh:/root/.ssh:ro
+      # Mount user's Git configuration
+      - ~/.gitconfig:/root/.gitconfig:ro
+      # Persist bash/fish history if desired (optional)
+      # You might need to create these files on the host first
+      # - ~/.ansible_dev_bash_history:/root/.bash_history
+      # - ~/.ansible_dev_fish_history:/root/.local/share/fish/fish_history
+    stdin_open: true # Keeps STDIN open even if not attached (-i)
+    tty: true        # Allocates a pseudo-TTY (-t)
+    environment:
+      # Pass the host user's UID and GID to handle file permissions correctly
+      # This is particularly useful if the container creates files in the mounted /data volume.
+      # The entrypoint script in the container would need to handle this.
+      # For now, we'll keep it simple and rely on default root user inside,
+      # but this is a common pattern for more advanced setups.
+      # HOST_USER_ID: "${UID:-1000}"
+      # HOST_GROUP_ID: "${GID:-1000}"
+      ANSIBLE_CONFIG: /data/ansible.cfg # Example if you have a project-specific ansible.cfg
+    # If you need to expose ports (e.g., if running a service that Ansible manages and want to test it locally)
+    # ports:
+    #   - "8080:80"
+    working_dir: /data
+    # The default CMD is /bin/bash from the Dockerfile.
+    # You can override it here if needed, e.g., to start with fish shell:
+    # command: /usr/bin/fish


### PR DESCRIPTION
This commit introduces a Docker-based local development environment for working with the Ansible playbooks.

Key changes include:
- A `Dockerfile` that sets up an Alpine-based image with Ansible, ansible-lint, Git, and other necessary tools.
- A `docker-compose.yml` file to simplify building and running the development container, including volume mounts for project files, SSH keys, and Git configuration.
- An internet connectivity check added as a pre_task to the main `deploy.yml` playbook to ensure necessary connections are available before running internet-dependent roles.
- Updated `README.md` with a new section detailing how to set up and use the Dockerized environment, including instructions for offline use and noting that this new setup supersedes the previous `ansible-ctrl.dockerfile` for local development.

The environment is designed to be Linux-compatible and support offline work once the Docker image is built.