### PR TITLE
Add agent policy manifest YAML and orchestrator workflow

### DIFF
--- a/.agent/policy_audit.py
+++ b/.agent/policy_audit.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""
+Minimal policy manifest audit.
+
+- Validates that docs/agent/policies/agent-policy-manifest.yaml is well-formed YAML.
+- Confirms that each canonical_doc path exists relative to the repo root.
+- Optionally warns about unreferenced policy markdown files under docs/agent/policies/.
+
+This script is structural only and does not generate or change policy content.
+For canonical policy definitions, see docs/agent/policies/ and the manifest docs.
+
+Usage (from repo root):
+  python .agent/policy_audit.py
+"""
+
+import sys
+import yaml
+from pathlib import Path
+
+
+def load_manifest(manifest_path: Path):
+    if not manifest_path.exists():
+        raise FileNotFoundError(f"Manifest not found: {manifest_path}")
+    text = manifest_path.read_text(encoding="utf-8")
+    data = yaml.safe_load(text)
+    if not isinstance(data, dict):
+        raise ValueError("Manifest root must be a mapping (expected keys like 'terms').")
+    terms = data.get("terms")
+    if not isinstance(terms, list):
+        raise ValueError("Manifest must contain a 'terms' list.")
+    return terms
+
+
+def check_canonical_docs(repo_root: Path, terms):
+    errors = []
+    for term in terms:
+        term_id = term.get("id") or term.get("name")
+        canonical_doc = term.get("canonical_doc")
+        if not canonical_doc:
+            errors.append(f"term {term_id!r} is missing canonical_doc")
+            continue
+        target = (repo_root / canonical_doc).resolve()
+        try:
+            target.relative_to(repo_root)
+        except ValueError:
+            errors.append(
+                f"term {term_id!r} canonical_doc path escapes repo root: {canonical_doc}"
+            )
+            continue
+        if not target.exists():
+            errors.append(
+                f"term {term_id!r} canonical_doc does not exist: {canonical_doc}"
+            )
+    return errors
+
+
+def find_unreferenced_policies(repo_root: Path, terms):
+    """Return list of .md policy files under docs/agent/policies/ that are not referenced in the manifest."""
+    policies_root = repo_root / "docs" / "agent" / "policies"
+    all_md = {
+        p.relative_to(repo_root)
+        for p in policies_root.glob("*.md")
+        if p.name not in {"INDEX.md", "agent-policy-manifest.md"}
+    }
+
+    referenced = set()
+    for term in terms:
+        canonical_doc = term.get("canonical_doc")
+        if canonical_doc:
+            referenced.add(Path(canonical_doc))
+
+    unreferenced = sorted(str(p) for p in all_md - referenced)
+    return unreferenced
+
+
+def main():
+    repo_root = Path(__file__).resolve().parent.parent
+    manifest_path = repo_root / "docs" / "agent" / "policies" / "agent-policy-manifest.yaml"
+
+    print(f"Using repo root: {repo_root}")
+    print(f"Loading manifest: {manifest_path}")
+
+    try:
+        terms = load_manifest(manifest_path)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[ERROR] Failed to load manifest: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    errors = check_canonical_docs(repo_root, terms)
+    if errors:
+        print("[ERROR] Policy manifest canonical_doc issues:")
+        for msg in errors:
+            print(f"  - {msg}")
+        # Non-zero exit to signal structural problems
+        sys.exit(1)
+
+    unreferenced = find_unreferenced_policies(repo_root, terms)
+    if unreferenced:
+        print("[WARN] Unreferenced policy markdown files (not listed in manifest):")
+        for path in unreferenced:
+            print(f"  - {path}")
+    else:
+        print("[OK] All policy markdown files are referenced in the manifest.")
+
+    print("[OK] Policy manifest structure validated.")
+
+
+if __name__ == "__main__":
+    main()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,16 +12,19 @@ Human- and agent-facing documentation is organized under the `docs/` tree using 
 
 For the authoritative view of this system, start from these canonical docs:
 
-- Agent docs index: [`docs/agent/INDEX.md`](docs/agent/INDEX.md:1)  
+- Agent docs index: [`docs/agent/INDEX.md`](docs/agent/INDEX.md:1)
   - Entry point for **all agent-focused** docs (policies, workflows, commands).
 
-- Contributing docs: [`docs/contributing.md`](docs/contributing.md:1)  
+- Agent policies index: [`docs/agent/policies/INDEX.md`](docs/agent/policies/INDEX.md:1)
+  - Entry point for agent-focused policy documents, including the machine-readable all-agent policy manifest at `docs/agent/policies/agent-policy-manifest.yaml`.
+
+- Contributing docs: [`docs/contributing.md`](docs/contributing.md:1)
   - How to add and maintain docs using the subject-based layout, YAML front matter, canonical docs, and link stubs.
 
-- Documentation policies index: [`docs/policies/INDEX.md`](docs/policies/INDEX.md:1)  
+- Documentation policies index: [`docs/policies/INDEX.md`](docs/policies/INDEX.md:1)
   - Repository-wide documentation policies, including log and content guidelines.
 
-- Always Link policy (canonical): [`docs/agent/policies/always-link.md`](docs/agent/policies/always-link.md:1)  
+- Always Link policy (canonical): [`docs/agent/policies/always-link.md`](docs/agent/policies/always-link.md:1)
   - “One canonical doc per concept, link stubs everywhere else.”
 
 HUMAN entrypoint:
@@ -38,22 +41,24 @@ AGENT entrypoint (this file):
 
 When operating in this repository:
 
-- **Prefer canonical docs under `docs/`**  
-  - Long-form explanations belong in `docs/`, not in `README.md`, `AGENTS.md`, or inline comments.  
+Canonical policies for AI agents live under `docs/agent/policies/` and are summarized in the agent policies index together with the machine-readable manifest at `docs/agent/policies/agent-policy-manifest.yaml`. Treat those files as the source of truth for which policies apply to you; this file only explains how to navigate and use those canonical docs.
+
+- **Prefer canonical docs under `docs/`**
+  - Long-form explanations belong in `docs/`, not in `README.md`, `AGENTS.md`, or inline comments.
   - If you see duplicated explanations, move the shared part into a canonical doc and leave link stubs behind.
 
-- **Respect the Always Link policy**  
-  - Ensure there is **exactly one** canonical doc per concept.  
-  - Other occurrences become short stubs that point to the canonical doc or section.  
+- **Respect the Always Link policy**
+  - Ensure there is **exactly one** canonical doc per concept.
+  - Other occurrences become short stubs that point to the canonical doc or section.
   - See [`docs/agent/policies/always-link.md`](docs/agent/policies/always-link.md:1).
 
-- **Use `.agent/` as your working area**  
-  - Temporary inventories, classifications, audits, and scratch materials live under `.agent/tmp/`.  
-  - Logs for non-trivial runs live under `.agent/log/`.  
+- **Use `.agent/` as your working area**
+  - Temporary inventories, classifications, audits, and scratch materials live under `.agent/tmp/`.
+  - Logs for non-trivial runs live under `.agent/log/`.
   - Follow the operational policies under `docs/agent/policies/` (workspace, logging, working directory, etc.).
 
-- **Prefer scripted, idempotent changes**  
-  - Use `.agent` tools instead of ad-hoc parsing when possible.  
+- **Prefer scripted, idempotent changes**
+  - Use `.agent` tools instead of ad-hoc parsing when possible.
   - Keep changes repeatable: re-running the workflow should not create duplicate docs or inconsistent links.
 
 - **User instructions win for the current task**  

--- a/docs/agent/commands/INDEX.md
+++ b/docs/agent/commands/INDEX.md
@@ -12,7 +12,7 @@ related:
   - "../workflows/update-docs.md"
   - "../policies/INDEX.md"
 owner: "Gnome Network Ansible maintainers"
-last_reviewed: "2025-11-20"
+last_reviewed: "2025-11-26"
 canonical_url: "docs/agent/commands/INDEX.md"
 ---
 
@@ -26,8 +26,8 @@ All commands referenced here live under the `.agent/` directory and should be tr
 
 ### Inventory generator
 
-- Script: [`doc_inventory.py`](../../.agent/doc_inventory.py:1)  
-- Purpose: Scans markdown documentation and produces an inventory of “documentation units” with signatures and source pointers.  
+- Script: [`doc_inventory.py`](../../.agent/doc_inventory.py:1)
+- Purpose: Scans markdown documentation and produces an inventory of “documentation units” with signatures and source pointers.
 - Typical usage:
 
   ```bash
@@ -38,8 +38,8 @@ All commands referenced here live under the `.agent/` directory and should be tr
 
 ### Classifier
 
-- Script: [`doc_classify.py`](../../.agent/doc_classify.py:1)  
-- Purpose: Consumes the inventory output and classifies units by subject, type, scope, and tags; also records canonical-doc mappings and duplicates.  
+- Script: [`doc_classify.py`](../../.agent/doc_classify.py:1)
+- Purpose: Consumes the inventory output and classifies units by subject, type, scope, and tags; also records canonical-doc mappings and duplicates.
 - Typical usage:
 
   ```bash
@@ -50,7 +50,7 @@ All commands referenced here live under the `.agent/` directory and should be tr
 
 ### Link auditor
 
-- Script: [`doc_audit.py`](../../.agent/doc_audit.py:1)  
+- Script: [`doc_audit.py`](../../.agent/doc_audit.py:1)
 - Purpose: Audits links across `docs/`, `README.md`, and `AGENTS.md` for:
   - Broken or invalid links.
   - Oversize docs that may need splitting.
@@ -62,6 +62,18 @@ All commands referenced here live under the `.agent/` directory and should be tr
   ```
 
 - Output: Writes an audit report under `.agent/tmp/audit.json` (ephemeral working data).
+
+### Policy manifest audit
+
+- Script: [`policy_audit.py`](../../.agent/policy_audit.py:1)
+- Purpose: Performs a structural audit of `docs/agent/policies/agent-policy-manifest.yaml`, validating YAML structure and `canonical_doc` paths, and warning about unreferenced policy markdown files.
+- Typical usage:
+
+  ```bash
+  python3 .agent/policy_audit.py
+  ```
+
+- Output: Prints results to stdout; may emit warnings about unreferenced policy docs.
 
 ## Working directory and logging
 

--- a/docs/agent/policies/INDEX.md
+++ b/docs/agent/policies/INDEX.md
@@ -15,7 +15,7 @@ related:
   - "agent-logging.md"
   - "working-directory.md"
 owner: "Gnome Network Ansible maintainers"
-last_reviewed: "2025-11-20"
+last_reviewed: "2025-11-26"
 canonical_url: "docs/agent/policies/INDEX.md"
 ---
 
@@ -24,6 +24,10 @@ canonical_url: "docs/agent/policies/INDEX.md"
 This index lists agent-focused policy documents. Each document under `docs/agent/policies/` is a canonical agent-facing policy or reference. The overall documentation model is defined in [`docs/agent/policies/always-link.md`](always-link.md:1).
 
 Use this page when you need to discover which high-level policies agents must follow and where their canonical definitions live.
+
+## All-agent policy manifest
+
+For a single, machine-readable index of the policies that apply to all agents, use the YAML manifest at `docs/agent/policies/agent-policy-manifest.yaml`. It lists policy identifiers and their canonical documents; the detailed policy content lives only in those canonical docs.
 
 ## Core agent policies
 

--- a/docs/agent/policies/agent-policy-manifest.yaml
+++ b/docs/agent/policies/agent-policy-manifest.yaml
@@ -1,0 +1,48 @@
+terms:
+  - id: always_link
+    name: always_link
+    category: docs
+    level: must
+    applies_to:
+      - all-agents
+    canonical_doc: docs/agent/policies/always-link.md
+
+  - id: agent_general_instructions
+    name: agent_general_instructions
+    category: behavior
+    level: must
+    applies_to:
+      - all-agents
+    canonical_doc: docs/agent/policies/general-instructions.md
+
+  - id: agent_operational_policies
+    name: agent_operational_policies
+    category: workspace
+    level: must
+    applies_to:
+      - all-agents
+    canonical_doc: docs/agent/policies/agent-operational-policies.md
+
+  - id: agent_workspace
+    name: agent_workspace
+    category: workspace
+    level: must
+    applies_to:
+      - all-agents
+    canonical_doc: docs/agent/policies/agent-workspace.md
+
+  - id: agent_logging
+    name: agent_logging
+    category: logging
+    level: must
+    applies_to:
+      - all-agents
+    canonical_doc: docs/agent/policies/agent-logging.md
+
+  - id: working_directory
+    name: working_directory
+    category: workspace
+    level: must
+    applies_to:
+      - all-agents
+    canonical_doc: docs/agent/policies/working-directory.md

--- a/docs/agent/workflows/orchestrator-agent-policies.md
+++ b/docs/agent/workflows/orchestrator-agent-policies.md
@@ -1,0 +1,94 @@
+---
+title: "Agent Workflow: Orchestrator Agent Policies"
+summary: "Workflow for orchestrator agents to apply the agent policy manifest when creating and managing subtasks."
+type: "how-to"
+scope: "repo"
+tags:
+  - "agent"
+  - "orchestrator"
+  - "workflow"
+  - "policy"
+related:
+  - "../INDEX.md"
+  - "../policies/INDEX.md"
+  - "../commands/INDEX.md"
+  - "../policies/general-instructions.md"
+owner: "Gnome Network Ansible maintainers"
+last_reviewed: "2025-11-26"
+canonical_url: "docs/agent/workflows/orchestrator-agent-policies.md"
+---
+
+# Agent Workflow: Orchestrator Agent Policies
+
+This workflow describes how the orchestrator agent should use the machine-readable manifest in `docs/agent/policies/agent-policy-manifest.yaml` to attach policy references to every subtask it spawns. It assumes you already follow the general instructions in [`docs/agent/policies/general-instructions.md`](../policies/general-instructions.md:1) and the documentation model in [`docs/agent/policies/always-link.md`](../policies/always-link.md:1).
+
+The orchestrator **does not restate policy content**. Instead, it reads the manifest, selects the relevant entries, and passes their IDs and canonical links into subtask prompts. Each subtask agent is responsible for reading the canonical policy documents when needed.
+
+## 1. Read the agent policy manifest
+
+Before building or updating a task tree, the orchestrator should load the YAML manifest:
+
+- Manifest file: `docs/agent/policies/agent-policy-manifest.yaml`
+- Structure: a top-level `terms` array, where each item includes:
+  - `id` and `name` (short identifier such as `always_link`, `agent_general_instructions`)
+  - `category` (for example `docs`, `workspace`, `logging`, `behavior`)
+  - `level` (`must` or `should`)
+  - `applies_to` (for this manifest, always includes `all-agents`)
+  - `canonical_doc` (relative path to the canonical policy doc under `docs/agent/policies/`)
+
+Treat the manifest as the **single source of truth** for which policies apply to all agents. The orchestrator should not hard-code policy paths or names; it should rely on the manifest instead.
+
+## 2. Classify the parent task
+
+When the orchestrator receives a top-level request, it should classify it into a simple task category. Examples:
+
+- `docs-edit` – editing or adding documentation only
+- `code-edit` – changing application, role, or Terraform code
+- `infra-edit` – updating infrastructure configuration or Terraform state
+- `tests-lint` – adding or fixing tests, lint rules, or CI configuration
+- `analysis-only` – reading, auditing, or summarizing without making changes
+
+This classification helps the orchestrator decide which **additional** policies or workflow docs to reference (for example, documentation workflows for `docs-edit`). However, **all** categories must still include the all-agent entries from the manifest.
+
+## 3. Build subtask policy context
+
+For each subtask the orchestrator creates (for example, a code-mode or docs-mode subtask), it should:
+
+1. Include all manifest terms where `applies_to` contains `all-agents`.
+2. Optionally filter or highlight entries by `level` (for example, call out `must` policies explicitly).
+3. Add any extra, task-specific references (such as role- or environment-specific docs) as separate links, not as new policy definitions.
+
+The orchestrator should pass policy context as **IDs plus links only**, leaving all normative text inside the canonical docs.
+
+## 4. Subtask prompt template (example)
+
+When creating a subtask, the orchestrator can inject a policy section similar to the following. The concrete wording may vary; the important part is that only IDs and links are provided, not restated policy content.
+
+```text
+Policy constraints
+------------------
+You MUST follow all policies in the agent policy manifest that apply to all agents. Relevant entries include (see canonical docs for details):
+- always_link → docs/agent/policies/always-link.md
+- agent_operational_policies → docs/agent/policies/agent-operational-policies.md
+- agent_workspace → docs/agent/policies/agent-workspace.md
+- agent_logging → docs/agent/policies/agent-logging.md
+- agent_general_instructions → docs/agent/policies/general-instructions.md
+- working_directory → docs/agent/policies/working-directory.md
+
+Consult the linked canonical documents for the full policy text. Do not copy those explanations into this task; link to them instead.
+```
+
+The orchestrator should derive this list from the manifest’s `terms` array, not from hard-coded constants, so that adding or updating policies only requires editing the manifest and canonical docs.
+
+## 5. Keep workflows and policies separate
+
+This workflow document explains **how** the orchestrator should use the manifest; it is **not** itself a policy definition. The canonical policy content continues to live under:
+
+- [`docs/agent/policies/always-link.md`](../policies/always-link.md:1)
+- [`docs/agent/policies/agent-operational-policies.md`](../policies/agent-operational-policies.md:1)
+- [`docs/agent/policies/agent-workspace.md`](../policies/agent-workspace.md:1)
+- [`docs/agent/policies/agent-logging.md`](../policies/agent-logging.md:1)
+- [`docs/agent/policies/general-instructions.md`](../policies/general-instructions.md:1)
+- [`docs/agent/policies/working-directory.md`](../policies/working-directory.md:1)
+
+When in doubt, the orchestrator should link back to these canonical docs rather than paraphrasing them in prompts or new workflow files.

--- a/docs/policies/INDEX.md
+++ b/docs/policies/INDEX.md
@@ -12,7 +12,7 @@ related:
   - "general-instructions.md"
   - "../contributing.md"
 owner: "Gnome Network Ansible maintainers"
-last_reviewed: "2025-11-19"
+last_reviewed: "2025-11-26"
 canonical_url: "docs/policies/INDEX.md"
 ---
 
@@ -32,12 +32,13 @@ Use this page as the starting point when you need to understand or update reposi
   High-level expectations for agents: understand the project first, respect canonical docs, prefer scripted/idempotent changes, and honor testing policies.
   See [`docs/agent/policies/general-instructions.md`](../agent/policies/general-instructions.md:1).
 
-- **Documentation contributing guide**  
-  How to write new docs that comply with the Always Link system, including required front matter, subjects, and slug rules.  
+- **Documentation contributing guide**
+  How to write new docs that comply with the Always Link system, including required front matter, subjects, and slug rules.
   See [`docs/contributing.md`](docs/contributing.md:1).
 
 ## How to use these policies
 
 - When adding or changing documentation, start from the contributing guide and Always Link policy.
 - When implementing automated agents or scripts, ensure they follow the general instructions and treat these policy docs as canonical sources.
+- For the current list of repository-wide policies that apply to all AI agents, see the agent policies index at [`docs/agent/policies/INDEX.md`](../agent/policies/INDEX.md:1), which references the machine-readable manifest at `docs/agent/policies/agent-policy-manifest.yaml`.
 - If a new policy is needed, add a bite-sized canonical doc under `docs/policies/` and link to it from here instead of embedding long text into `README.md` or `AGENTS.md`.


### PR DESCRIPTION
Summary
-------
This PR adds a machine-readable agent policy manifest and an orchestrator workflow, wiring them into AGENTS.md and the agent policy indexes without duplicating canonical policy text.

Key changes
-----------
- Added YAML manifest:
  - `docs/agent/policies/agent-policy-manifest.yaml`
  - Defines `terms` with `id`, `name`, `category`, `level`, `applies_to`, and `canonical_doc`.
  - Indexes only metadata and canonical paths; all policy prose stays in existing policy docs.

- Updated entrypoints:
  - `AGENTS.md` — remains the primary entrypoint for AI agents and now points to:
    - `docs/agent/INDEX.md` for agent docs.
    - `docs/agent/policies/INDEX.md` for policies, explicitly noting the YAML manifest.
  - `docs/agent/policies/INDEX.md` — adds an “All-agent policy manifest” section that points directly to the YAML manifest.
  - `docs/policies/INDEX.md` — “How to use these policies” now directs agents via `docs/agent/policies/INDEX.md`, which references the manifest.

- Added orchestrator workflow:
  - `docs/agent/workflows/orchestrator-agent-policies.md`
  - Explains how the orchestrator reads the YAML manifest and injects policy IDs + links into subtasks, leaving all normative text in:
    - `docs/agent/policies/always-link.md`
    - `docs/agent/policies/agent-operational-policies.md`
    - `docs/agent/policies/agent-workspace.md`
    - `docs/agent/policies/agent-logging.md`
    - `docs/agent/policies/general-instructions.md`
    - `docs/agent/policies/working-directory.md`

- Added structural manifest audit:
  - `.agent/policy_audit.py` and the corresponding entry in `docs/agent/commands/INDEX.md`.
  - Validates manifest YAML structure and `canonical_doc` paths, and warns on unreferenced `docs/agent/policies/*.md` files.