### PR TITLE
feat(opencode): add GitHub MCP and Agent Memory

### DIFF
--- a/.agent/MEMORY.md
+++ b/.agent/MEMORY.md
@@ -1,0 +1,34 @@
+# Long-term Memory (Layer 2)
+
+## System Context
+- **Repository**: gnome-network-ansible
+- **Type**: Ansible playbook for GNOME network configuration
+- **Core Functionality**: Automated provisioning and configuration management
+
+## Project Standards
+
+- **Language**: Ansible YAML
+- **Testing**: Molecule for role testing
+- **Linting**: ansible-lint
+- **Documentation**: Markdown in `docs/`
+
+## Durable Facts
+
+<!--
+  Store critical, unchanging facts about the project here.
+  Examples:
+  - "Auth service requires JWT signed by key X"
+  - "Database migrations must be run manually in prod"
+  - "External API X has a rate limit of 100 req/min"
+-->
+- Memory Structure: Three-layer stack in `.agent/`
+
+## Distilled Wisdom
+
+<!--
+  Capture lessons learned and recurring patterns here.
+  Periodically extract insights from daily logs (Layer 1) and summarize them here.
+  Examples:
+  - "Always mock the payment gateway in local dev"
+  - "Component X is fragile; change with caution"
+-->

--- a/.agent/NOW.md
+++ b/.agent/NOW.md
@@ -1,0 +1,29 @@
+# Current Context (Layer 3)
+
+## Active Tasks
+
+<!--
+  List current priorities and active work.
+  Update at session start and as priorities shift.
+-->
+- None currently
+
+## Recent Updates
+
+<!--
+  Note recent changes, decisions, or progress.
+-->
+- 
+
+## Blockers
+
+<!--
+  Document current impediments.
+-->
+- None
+
+## Notes
+
+<!--
+ 临时 notes for current session
+-->

--- a/.agent/memory/README.md
+++ b/.agent/memory/README.md
@@ -1,0 +1,27 @@
+# Daily Logs
+
+This directory stores ephemeral daily working logs.
+
+## Purpose
+
+- Task breakdown and progress tracking
+- Research findings
+- Draft content
+- Working notes
+
+## Format
+
+Filename: `YYYY-MM-DD.md`
+
+Example: `2025-01-15.md`
+
+## Lifecycle
+
+- Created by agents during work sessions
+- Referenced for context in subsequent sessions
+- Can be reviewed for patterns and insights
+- Periodically cleaned up (older logs can be archived or deleted)
+
+## Best Practice
+
+Extract durable insights to `../MEMORY.md` before deleting daily logs.

--- a/.agent/workspace/README.md
+++ b/.agent/workspace/README.md
@@ -1,0 +1,65 @@
+# Agent Workspace
+
+This directory is a **temporary scratchpad** for ephemeral working files. It complements the durable memory layers by providing a space for transient work that doesn't belong in the permanent knowledge base.
+
+## Purpose
+
+The workspace is designed for:
+- **Task breakdowns**: Detailed plans, step-by-step checklists, and subtask decomposition
+- **Temporary outputs**: Intermediate results, draft content, and working files
+- **Scratch notes**: Quick observations, temporary analysis, and exploratory work
+- **Active context**: Files needed during current work that will be discarded or promoted
+
+## Memory vs. Workspace
+
+| Aspect | Memory (Layers 1-3) | Workspace |
+|--------|---------------------|-----------|
+| **Purpose** | Durable, searchable knowledge base | Temporary scratchpad |
+| **Lifespan** | Permanent (or archived) | Ephemeral (cleaned regularly) |
+| **Content** | Facts, decisions, wisdom, context | Plans, drafts, temporary outputs |
+| **Audience** | Agent + Human | Agent + Human |
+| **Searchable** | Yes (indexed for retrieval) | No (transient by design) |
+
+## Characteristics
+
+- **Not committed to version control**: Excluded from git
+- **Ephemeral**: Files can be deleted without loss of critical information
+- **Short-lived**: Content should be promoted to memory or discarded after use
+- **Flexible**: No strict format requirements; use what works for the task
+
+## Best Practices
+
+### For Agents
+1. **Use for active work**: Store task lists, plans, and temporary outputs here
+2. **Promote important insights**: Move valuable information to `../MEMORY.md` or `../NOW.md`
+3. **Clean regularly**: Remove obsolete files after task completion
+4. **Organize by task**: Use subdirectories or clear naming for different work streams
+
+### For Humans
+1. **Review before cleaning**: Check workspace for insights before deletion
+2. **Don't rely on workspace**: Assume files may be deleted at any time
+3. **Extract value**: Promote useful content to permanent memory layers
+4. **Clean periodically**: Remove stale files to maintain workspace hygiene
+
+## Example Use Cases
+
+- Breaking down complex tasks into subtasks
+- Storing intermediate analysis results
+- Drafting documentation before finalizing
+- Maintaining temporary checklists
+- Collecting research notes during investigation
+- Prototyping code snippets or configurations
+- Tracking progress on multi-step workflows
+
+## Workflow
+
+```
+1. Agent starts task → Creates workspace files (plans, checklists)
+2. Agent works → Updates workspace files with progress
+3. Task completes → Extract insights to MEMORY.md or NOW.md
+4. Cleanup → Delete workspace files or archive if needed
+```
+
+---
+
+*This workspace keeps your permanent memory layers clean while providing flexibility for active work. Clean regularly to maintain hygiene.*

--- a/.env.example.github-mcp
+++ b/.env.example.github-mcp
@@ -1,0 +1,4 @@
+# GitHub MCP Server Configuration
+# Copy to $HOME/.env/github-mcp.env and configure with your token
+
+GITHUB_PERSONAL_ACCESS_TOKEN=your_github_token_here

--- a/.opencode/skills/agent-memory/SKILL.md
+++ b/.opencode/skills/agent-memory/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: agent-memory
+description: Three-layer memory system for AI agents. Use at session start to read context, and during work to log insights and extract durable facts.
+compatibility: opencode
+metadata:
+  repo: gnome-network-ansible
+---
+
+# Agent Memory
+
+## Overview
+
+This repository uses a three-layer memory system to maintain context across sessions and capture durable knowledge.
+
+## Layers
+
+| Layer | File | Purpose |
+|-------|------|---------|
+| 1 | `.agent/memory/YYYY-MM-DD.md` | Daily working logs - ephemeral |
+| 2 | `.agent/MEMORY.md` | Long-term facts and wisdom - durable |
+| 3 | `.agent/NOW.md` | Current task context - operational |
+
+## When to Use
+
+### At Session Start
+
+1. Read `.agent/MEMORY.md` for project context
+2. Read `.agent/NOW.md` for current priorities
+3. Check `.agent/memory/` for recent activity
+
+### During Work
+
+1. Log progress to `.agent/memory/YYYY-MM-DD.md`
+2. Create temporary files in `.agent/workspace/`
+3. Note discoveries, decisions, and insights
+
+### At Session End
+
+1. Extract durable facts to `.agent/MEMORY.md`
+2. Update `.agent/NOW.md` with current state
+3. Clean up `.agent/workspace/` if needed
+
+## Best Practices
+
+- **Layer 1 is ephemeral**: Don't rely on daily logs persisting forever
+- **Layer 2 is durable**: Only store facts that won't change
+- **Layer 3 is operational**: Keep current, update as tasks progress
+- **Link don't duplicate**: Reference docs instead of copying content
+- **Promote insights**: Move valuable observations from daily logs to MEMORY.md
+
+## File Purposes
+
+### Layer 1: Daily Logs (`.agent/memory/`)
+
+- Task breakdown and progress
+- Research findings
+- Draft content and working notes
+- Scratch calculations
+
+### Layer 2: Long-term Memory (`.agent/MEMORY.md`)
+
+- Project architecture facts
+- Key conventions and standards
+- Lessons learned (extracted from daily logs)
+- Important relationships between components
+
+### Layer 3: Now (`.agent/NOW.md`)
+
+- Current active tasks
+- Priorities for today
+- Blockers and dependencies
+- Recent decisions needing follow-up
+
+### Workspace (`.agent/workspace/`)
+
+- Temporary files for active work
+- Files that can be deleted without loss
+- Intermediate drafts
+- Task-specific checklists
+
+## Related
+
+- [canonical-docs](canonical-docs): Documentation system
+- [github-branch-management](github-branch-management): Branch and commit conventions

--- a/.opencode/skills/github-branch-management/SKILL.md
+++ b/.opencode/skills/github-branch-management/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: github-branch-management
+description: Create, manage, and merge GitHub branches following conventional commit standards. Use when working with git branches, creating PRs, or committing code changes.
+compatibility: Requires GitHub MCP server configured with GITHUB_PERSONAL_ACCESS_TOKEN
+metadata:
+  author: trackforce
+  version: "1.0"
+---
+
+# GitHub Branch Management
+
+## When to use this skill
+
+Use this skill when the user needs to:
+- Create new branches with proper naming conventions
+- Make commits following conventional commit format
+- Create pull requests with proper descriptions
+- Merge branches with appropriate strategies
+- Manage branch lifecycle (create, update, delete)
+
+## Branch Naming Conventions
+
+Follow these patterns for branch names:
+
+| Type | Pattern | Example | When to Use |
+|------|---------|---------|-------------|
+| `feature/` | `feature/description` | `feature/user-authentication` | New features or enhancements |
+| `fix/` | `fix/description` | `fix/login-validation` | Bug fixes |
+| `chore/` | `chore/description` | `chore/update-dependencies` | Maintenance tasks |
+| `docs/` | `docs/description` | `docs/api-reference` | Documentation updates |
+| `refactor/` | `refactor/description` | `refactor/auth-module` | Code refactoring |
+| `test/` | `test/description` | `test/integration-suite` | Test additions |
+
+**Rules**:
+- Use lowercase with hyphens (kebab-case)
+- Be descriptive but concise
+- No special characters except hyphens
+- Maximum 50 characters
+
+## Conventional Commit Format
+
+All commits MUST follow the [Conventional Commits](https://www.conventionalcommits.org/) specification:
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+### Commit Types
+
+| Type | Purpose | Example |
+|------|---------|---------|
+| `feat` | New feature | `feat(auth): add OAuth2 support` |
+| `fix` | Bug fix | `fix(api): handle null response` |
+| `docs` | Documentation | `docs(readme): update installation steps` |
+| `style` | Formatting | `style(ui): fix button alignment` |
+| `refactor` | Code restructuring | `refactor(db): optimize query performance` |
+| `test` | Tests | `test(auth): add login unit tests` |
+| `chore` | Maintenance | `chore(deps): update dependencies` |
+| `perf` | Performance | `perf(api): cache frequent queries` |
+| `ci` | CI/CD | `ci(github): add automated tests` |
+| `build` | Build system | `build(webpack): update config` |
+| `revert` | Revert changes | `revert: feat(auth): add OAuth2` |
+
+### Commit Message Guidelines
+
+**Subject line** (first line):
+- Max 72 characters
+- Imperative mood ("add" not "added" or "adds")
+- No period at the end
+- Lowercase after type/scope
+
+**Body** (optional):
+- Wrap at 72 characters
+- Explain what and why, not how
+- Separate from subject with blank line
+
+**Footer** (optional):
+- Breaking changes: `BREAKING CHANGE: description`
+- Issue references: `Closes #123`, `Fixes #456`
+
+### Examples
+
+```
+feat(auth): add JWT token refresh mechanism
+
+Implements automatic token refresh before expiration.
+Reduces user session interruptions.
+
+Closes #234
+```
+
+```
+fix(api): prevent race condition in user creation
+
+Added mutex lock to ensure atomic user creation.
+Prevents duplicate user records.
+
+BREAKING CHANGE: User creation endpoint now returns 201 instead of 200
+```
+
+## GitHub MCP Tools Usage
+
+### Creating a Branch
+
+Use `mcp-github-mcp-create_branch`:
+
+```
+<use_mcp_tool>
+  <server_name>github-mcp</server_name>
+  <tool_name>create_branch</tool_name>
+  <arguments>{
+    "owner": "repository-owner",
+    "repo": "repository-name",
+    "branch": "feature/new-feature-name",
+    "from_branch": "main"
+  }</arguments>
+</use_mcp_tool>
+```
+
+### Creating a Pull Request
+
+Use `mcp-github-mcp-create_pull_request`:
+
+```
+<use_mcp_tool>
+  <server_name>github-mcp</server_name>
+  <tool_name>create_pull_request</tool_name>
+  <arguments>{
+    "owner": "repository-owner",
+    "repo": "repository-name",
+    "title": "feat(auth): add OAuth2 support",
+    "body": "## Description\n\nImplements OAuth2 authentication...\n\n## Changes\n- Added OAuth2 provider\n- Updated auth middleware\n\nCloses #123",
+    "head": "feature/oauth2-support",
+    "base": "main",
+    "draft": false
+  }</arguments>
+</use_mcp_tool>
+```
+
+### Listing Branches
+
+Use `mcp-github-mcp-list_branches`:
+
+```
+<use_mcp_tool>
+  <server_name>github-mcp</server_name>
+  <tool_name>list_branches</tool_name>
+  <arguments>{
+    "owner": "repository-owner",
+    "repo": "repository-name"
+  }</arguments>
+</use_mcp_tool>
+```
+
+### Merging a Pull Request
+
+Use `mcp-github-mcp-merge_pull_request`:
+
+```
+<use_mcp_tool>
+  <server_name>github-mcp</server_name>
+  <tool_name>merge_pull_request</tool_name>
+  <arguments>{
+    "owner": "repository-owner",
+    "repo": "repository-name",
+    "pullNumber": 123,
+    "merge_method": "squash",
+    "commit_title": "feat(auth): add OAuth2 support (#123)",
+    "commit_message": "Implements OAuth2 authentication with JWT tokens"
+  }</arguments>
+</use_mcp_tool>
+```
+
+## Workflow Patterns
+
+### Feature Development Workflow
+
+1. **Create feature branch** from `main`:
+   ```
+   feature/descriptive-name
+   ```
+
+2. **Make commits** following conventional format:
+   ```
+   feat(module): add new functionality
+   fix(module): resolve specific issue
+   docs(module): update documentation
+   ```
+
+3. **Create pull request** with:
+   - Clear title following conventional format
+   - Description with context and changes
+   - Link to related issues
+
+4. **Merge** using appropriate strategy:
+   - `squash`: For feature branches (recommended)
+   - `merge`: For release branches
+   - `rebase`: For clean history (use with caution)
+
+### Hotfix Workflow
+
+1. **Create fix branch** from `main`:
+   ```
+   fix/critical-bug-description
+   ```
+
+2. **Make fix commit**:
+   ```
+   fix(critical): resolve production issue
+
+   Detailed explanation of the fix.
+
+   Fixes #urgent-issue-number
+   ```
+
+3. **Create PR** with `urgent` or `hotfix` label
+
+4. **Merge immediately** after review using `squash`
+
+### Release Workflow
+
+1. **Create release branch**:
+   ```
+   release/v1.2.0
+   ```
+
+2. **Make version bump commit**:
+   ```
+   chore(release): bump version to 1.2.0
+   ```
+
+3. **Create PR** to `main` with changelog
+
+4. **Merge** using `merge` strategy to preserve history
+
+## Best Practices
+
+1. **Always pull latest** before creating a branch
+2. **Keep branches short-lived** (< 1 week)
+3. **One feature per branch** - avoid scope creep
+4. **Commit frequently** with meaningful messages
+5. **Rebase on main** regularly to avoid conflicts
+6. **Delete merged branches** to keep repository clean
+7. **Use draft PRs** for work-in-progress
+8. **Request reviews** before merging
+9. **Run tests** before creating PR
+10. **Update documentation** in the same PR
+
+## Common Mistakes to Avoid
+
+- ❌ Vague branch names: `fix-stuff`, `updates`
+- ❌ Non-conventional commits: `fixed bug`, `WIP`
+- ❌ Missing scope in commits when applicable
+- ❌ Long-lived feature branches
+- ❌ Committing directly to `main`
+- ❌ Force pushing to shared branches
+- ❌ Merging without review
+- ❌ Incomplete PR descriptions
+
+## Reference Materials
+
+For detailed conventional commit specification, see [`references/CONVENTIONS.md`](references/CONVENTIONS.md).
+
+## Troubleshooting
+
+### Branch Already Exists
+If branch creation fails due to existing branch:
+1. List branches to verify
+2. Use different branch name or delete old branch
+3. Ensure you're not accidentally recreating a merged branch
+
+### Merge Conflicts
+If PR has conflicts:
+1. Pull latest `main` into your branch
+2. Resolve conflicts locally
+3. Commit resolution with message: `chore: resolve merge conflicts`
+4. Push updated branch
+
+### Failed CI/CD
+If automated checks fail:
+1. Review CI logs in PR
+2. Fix issues locally
+3. Commit fixes following conventional format
+4. Push to update PR

--- a/.opencode/skills/github-branch-management/references/CONVENTIONS.md
+++ b/.opencode/skills/github-branch-management/references/CONVENTIONS.md
@@ -1,0 +1,251 @@
+# Conventional Commits Specification
+
+## Summary
+
+The Conventional Commits specification is a lightweight convention on top of commit messages. It provides an easy set of rules for creating an explicit commit history, which makes it easier to write automated tools on top of.
+
+**Version**: 1.0.0
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.
+
+1. Commits MUST be prefixed with a type, which consists of a noun, `feat`, `fix`, etc., followed by the OPTIONAL scope, OPTIONAL `!`, and REQUIRED terminal colon and space.
+
+2. The type `feat` MUST be used when a commit adds a new feature to your application or library.
+
+3. The type `fix` MUST be used when a commit represents a bug fix for your application.
+
+4. A scope MAY be provided after a type. A scope MUST consist of a noun describing a section of the codebase surrounded by parenthesis, e.g., `fix(parser):`.
+
+5. A description MUST immediately follow the colon and space after the type/scope prefix. The description is a short summary of the code changes, e.g., `fix: array parsing issue when multiple spaces were contained in string`.
+
+6. A longer commit body MAY be provided after the short description, providing additional contextual information about the code changes. The body MUST begin one blank line after the description.
+
+7. A commit body is free-form and MAY consist of any number of newline separated paragraphs.
+
+8. One or more footers MAY be provided one blank line after the body. Each footer MUST consist of a word token, followed by either a `:<space>` or `<space>#` separator, followed by a string value (this is inspired by the git trailer convention).
+
+9. A footer's token MUST use `-` in place of whitespace characters, e.g., `Acked-by` (this helps differentiate the footer section from a multi-paragraph body). An exception is made for `BREAKING CHANGE`, which MAY also be used as a token.
+
+10. A footer's value MAY contain spaces and newlines, and parsing MUST terminate when the next valid footer token/separator pair is observed.
+
+11. Breaking changes MUST be indicated in the type/scope prefix of a commit, or as an entry in the footer.
+
+12. If included as a footer, a breaking change MUST consist of the uppercase text BREAKING CHANGE, followed by a colon, space, and description, e.g., `BREAKING CHANGE: environment variables now take precedence over config files`.
+
+13. If included in the type/scope prefix, breaking changes MUST be indicated by a `!` immediately before the `:`. If `!` is used, `BREAKING CHANGE:` MAY be omitted from the footer section, and the commit description SHALL be used to describe the breaking change.
+
+14. Types other than `feat` and `fix` MAY be used in your commit messages, e.g., `docs: update ref docs`.
+
+15. The units of information that make up Conventional Commits MUST NOT be treated as case sensitive by implementors, with the exception of BREAKING CHANGE which MUST be uppercase.
+
+16. BREAKING-CHANGE MUST be synonymous with BREAKING CHANGE, when used as a token in a footer.
+
+## Why Use Conventional Commits
+
+- Automatically generating CHANGELOGs
+- Automatically determining a semantic version bump (based on the types of commits landed)
+- Communicating the nature of changes to teammates, the public, and other stakeholders
+- Triggering build and publish processes
+- Making it easier for people to contribute to your projects, by allowing them to explore a more structured commit history
+
+## Commit Types
+
+### Primary Types
+
+- **feat**: A new feature for the user
+- **fix**: A bug fix for the user
+
+### Additional Types
+
+The following types are commonly used but not required by the specification:
+
+- **build**: Changes that affect the build system or external dependencies
+- **chore**: Changes to the build process or auxiliary tools
+- **ci**: Changes to CI configuration files and scripts
+- **docs**: Documentation only changes
+- **perf**: A code change that improves performance
+- **refactor**: A code change that neither fixes a bug nor adds a feature
+- **revert**: Reverts a previous commit
+- **style**: Changes that do not affect the meaning of the code (white-space, formatting, etc)
+- **test**: Adding missing tests or correcting existing tests
+
+## Examples
+
+### Commit message with description and breaking change footer
+
+```
+feat: allow provided config object to extend other configs
+
+BREAKING CHANGE: `extends` key in config file is now used for extending other config files
+```
+
+### Commit message with `!` to draw attention to breaking change
+
+```
+feat!: send an email to the customer when a product is shipped
+```
+
+### Commit message with scope and `!` to draw attention to breaking change
+
+```
+feat(api)!: send an email to the customer when a product is shipped
+```
+
+### Commit message with both `!` and BREAKING CHANGE footer
+
+```
+chore!: drop support for Node 6
+
+BREAKING CHANGE: use JavaScript features not available in Node 6.
+```
+
+### Commit message with no body
+
+```
+docs: correct spelling of CHANGELOG
+```
+
+### Commit message with scope
+
+```
+feat(lang): add Polish language
+```
+
+### Commit message with multi-paragraph body and multiple footers
+
+```
+fix: prevent racing of requests
+
+Introduce a request id and a reference to latest request. Dismiss
+incoming responses other than from latest request.
+
+Remove timeouts which were used to mitigate the racing issue but are
+obsolete now.
+
+Reviewed-by: Z
+Refs: #123
+```
+
+## Scope
+
+A scope is an optional part of the commit message that provides additional contextual information. It should be a noun describing a section of the codebase.
+
+### Common Scopes by Project Type
+
+**Web Application**:
+- `api`: Backend API changes
+- `ui`: User interface changes
+- `auth`: Authentication/authorization
+- `db`: Database changes
+- `config`: Configuration changes
+
+**Library/Package**:
+- `core`: Core functionality
+- `utils`: Utility functions
+- `types`: Type definitions
+- `deps`: Dependencies
+
+**Microservices**:
+- `user-service`: User service changes
+- `payment-service`: Payment service changes
+- `gateway`: API gateway changes
+
+## Breaking Changes
+
+Breaking changes MUST be indicated by:
+
+1. Adding `!` after the type/scope: `feat(api)!: remove deprecated endpoint`
+2. Adding `BREAKING CHANGE:` footer with description
+
+### When to Mark as Breaking Change
+
+- Removing or renaming public APIs
+- Changing function signatures
+- Removing configuration options
+- Changing default behavior
+- Requiring new dependencies
+- Changing data formats
+- Removing features
+
+## Best Practices
+
+1. **Be Atomic**: Each commit should represent a single logical change
+2. **Be Descriptive**: Write clear, concise descriptions
+3. **Use Imperative Mood**: "add feature" not "added feature"
+4. **Limit Subject Line**: Keep under 72 characters
+5. **Separate Subject from Body**: Use blank line
+6. **Wrap Body**: Wrap at 72 characters
+7. **Explain Why**: Body should explain why, not what
+8. **Reference Issues**: Use footers to reference issues/tickets
+
+## Tools and Automation
+
+### Commitizen
+
+Interactive CLI for creating conventional commits:
+
+```bash
+npm install -g commitizen
+commitizen init cz-conventional-changelog --save-dev --save-exact
+```
+
+### Commitlint
+
+Lint commit messages:
+
+```bash
+npm install --save-dev @commitlint/cli @commitlint/config-conventional
+```
+
+### Standard Version
+
+Automate versioning and CHANGELOG generation:
+
+```bash
+npm install --save-dev standard-version
+```
+
+### Semantic Release
+
+Fully automated version management and package publishing:
+
+```bash
+npm install --save-dev semantic-release
+```
+
+## FAQ
+
+### Should I use conventional commits for all commits?
+
+Yes, especially for public projects. For private projects, teams should agree on adoption.
+
+### What if a commit fits multiple types?
+
+Choose the most significant type. If truly multiple changes, consider splitting into multiple commits.
+
+### How do I handle reverts?
+
+Use `revert:` type and reference the reverted commit:
+
+```
+revert: feat(api): add new endpoint
+
+This reverts commit 1234567.
+```
+
+### Can I use custom types?
+
+Yes, but document them for your team. Common custom types include `wip`, `hotfix`, `release`.
+
+### How do I handle merge commits?
+
+Merge commits typically don't follow conventional format. Use squash merging to maintain conventional history.
+
+## References
+
+- [Conventional Commits Specification](https://www.conventionalcommits.org/)
+- [Semantic Versioning](https://semver.org/)
+- [Keep a Changelog](https://keepachangelog.com/)
+- [Angular Commit Guidelines](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,8 @@ This repository provides OpenCode skills and commands for documentation workflow
 - **[update-docs](.opencode/skills/update-docs/SKILL.md)**: Complete workflow for updating documentation
 - **[canonical-docs](.opencode/skills/canonical-docs/SKILL.md)**: Always Link policy definition
 - **[agent-instructions](.opencode/skills/agent-instructions/SKILL.md)**: General rules for AI agents
+- **[github-branch-management](.opencode/skills/github-branch-management/SKILL.md)**: Branch and commit conventions
+- **[agent-memory](.opencode/skills/agent-memory/SKILL.md)**: Three-layer memory system
 
 ## Key Rules
 
@@ -31,6 +33,61 @@ This repository provides OpenCode skills and commands for documentation workflow
 2. Prefer canonical docs under `docs/` - don't duplicate
 3. Run `/doc-audit` after doc changes
 4. User instructions win over policies
+
+## GitHub MCP Server
+
+This repository supports the GitHub MCP Server for GitHub operations.
+
+### Configuration
+
+1. Copy `.env.example.github-mcp` to `~/.env/github-mcp.env` and add your GitHub PAT
+2. Add to `~/.config/opencode/opencode.json`:
+
+```json
+{
+  "mcp": {
+    "github": {
+      "type": "remote",
+      "url": "https://api.githubcopilot.com/mcp/",
+      "enabled": true
+    }
+  }
+}
+```
+
+### Required Scopes
+
+Your GitHub Personal Access Token needs:
+- `repo` - Repository operations
+- `read:org` - Organization team access (if using org features)
+
+### Tools Available
+
+With GitHub MCP Server, agents can:
+- Browse and search repositories
+- Manage issues and pull requests
+- View and trigger GitHub Actions
+- Analyze code and security findings
+
+## Agent Memory
+
+This repository uses a three-layer memory system in `.agent/`.
+
+### Layers
+
+| Layer | File/Directory | Purpose |
+|-------|----------------|---------|
+| 1 | `.agent/memory/` | Daily logs - ephemeral |
+| 2 | `.agent/MEMORY.md` | Long-term facts - durable |
+| 3 | `.agent/NOW.md` | Current context - operational |
+
+### Usage
+
+- **Start of session**: Read MEMORY.md and NOW.md
+- **During work**: Log progress to memory/YYYY-MM-DD.md
+- **End of session**: Extract insights to MEMORY.md, update NOW.md
+
+See [agent-memory](.opencode/skills/agent-memory/SKILL.md) for full documentation.
 
 ## For Docs Changes
 


### PR DESCRIPTION
## Summary
- Add GitHub MCP Server configuration template (`.env.example.github-mcp`)
- Add Agent Memory skill with three-layer memory system (`.opencode/skills/agent-memory/`)
- Add Agent Memory files (`.agent/`)
- Add GitHub Branch Management skill (`.opencode/skills/github-branch-management/`)
- Update `AGENTS.md` with documentation for all new features

## Changes
- Created `.env.example.github-mcp` as template for GitHub MCP configuration
- Created `.opencode/skills/agent-memory/SKILL.md` with full memory system documentation
- Created `.agent/` directory with:
  - `MEMORY.md` (Layer 2: Long-term memory)
  - `NOW.md` (Layer 3: Current context)
  - `memory/` (Layer 1: Daily logs)
  - `workspace/` (Ephemeral working files)
- Added GitHub Branch Management skill for conventional commits and branch management
- Updated `AGENTS.md` with sections for GitHub MCP, Agent Memory, and both skills