### PR TITLE
fix(opencode): update GitHub MCP config docs

### DIFF
--- a/.env.example.github-mcp
+++ b/.env.example.github-mcp
@@ -1,4 +1,0 @@
-# GitHub MCP Server Configuration
-# Copy to $HOME/.env/github-mcp.env and configure with your token
-
-GITHUB_PERSONAL_ACCESS_TOKEN=your_github_token_here

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,11 +49,16 @@ This repository supports the GitHub MCP Server for GitHub operations.
     "github": {
       "type": "remote",
       "url": "https://api.githubcopilot.com/mcp/",
-      "enabled": true
+      "enabled": true,
+      "headers": {
+        "Authorization": "Bearer YOUR_GITHUB_TOKEN_HERE"
+      }
     }
   }
 }
 ```
+
+**Note**: Hardcode the token directly in the config - the `${GITHUB_PERSONAL_ACCESS_TOKEN}` variable expansion won't work because OpenCode doesn't automatically load env files.
 
 ### Required Scopes
 


### PR DESCRIPTION
## Summary

- Update AGENTS.md to include proper `headers` configuration for GitHub MCP
- Add note explaining that OpenCode doesn't auto-load env files
- Remove unused `.env.example.github-mcp` file