### PR TITLE
docs: remove unused variables from .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,5 @@
 # Hindsight LLM Configuration
 HINDSIGHT_API_LLM_API_KEY=your_gemini_api_key_here
 
-# Ansible Vault Passwords (required for provisioning/install playbooks)
-SSH_PASSWORD=your_ssh_password
-ENCRYPTION_PASSWORD=your_encryption_password
-USER_PASSWORD=your_user_password
-
 # User (auto-set by docker compose from host environment)
 # USER=your_username


### PR DESCRIPTION
## Summary

- Removes `SSH_PASSWORD`, `ENCRYPTION_PASSWORD`, and `USER_PASSWORD` from `.env.example`
- These secrets are managed through Ansible Vault (`vault.yml`), not environment variables
- Only `HINDSIGHT_API_LLM_API_KEY` remains as it is the only env var consumed by `docker-compose.yml`

Closes #70