### PR TITLE
feat(tools): migrate to mise package manager and task runner

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -14,17 +14,13 @@ jobs:
   lint:
     name: Lint Ansible Code
     runs-on: ubuntu-latest
-    container: ghcr.io/jdx/mise:alpine
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Trust mise config
-        run: mise trust mise.toml
-
-      - name: Install tools
-        run: mise install
+      - name: Install mise
+        uses: jdx/mise-action@v2
 
       - name: Create dummy vault password
         run: echo "dummy" > .vault_password

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -20,8 +20,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Install mise
-        uses: jdx/mise-action@v2
+      - name: Trust mise config
+        run: mise trust mise.toml
+
+      - name: Install tools
+        run: mise install
 
       - name: Create dummy vault password
         run: echo "dummy" > .vault_password

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -14,6 +14,7 @@ jobs:
   lint:
     name: Lint Ansible Code
     runs-on: ubuntu-latest
+    container: ghcr.io/jdx/mise:alpine
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -19,19 +19,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.11'
-          cache: 'pip'
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-
-      - name: Display ansible-lint version
-        run: ansible-lint --version
+      - name: Install mise
+        uses: jdx/mise-action@v2
 
       - name: Create dummy vault password
         run: echo "dummy" > .vault_password
@@ -40,7 +29,7 @@ jobs:
         run: ansible-galaxy collection install -r requirements.yml
 
       - name: Run ansible-lint
-        run: ansible-lint install.yml provision.yml roles/
+        run: mise run lint
         env:
           PY_COLORS: '1'
           ANSIBLE_FORCE_COLOR: '1'

--- a/.github/workflows/molecule-test.yml
+++ b/.github/workflows/molecule-test.yml
@@ -118,7 +118,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Run Molecule tests
-        run: mise run molecule-test ${{ matrix.role }}
+        run: mise run molecule ${{ matrix.role }}
         env:
           PY_COLORS: '1'
           ANSIBLE_FORCE_COLOR: '1'

--- a/.github/workflows/molecule-test.yml
+++ b/.github/workflows/molecule-test.yml
@@ -111,27 +111,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.11'
-          cache: 'pip'
+      - name: Install mise
+        uses: jdx/mise-action@v2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-
-      - name: Display Molecule version
-        run: molecule --version
-
       - name: Run Molecule tests
-        run: |
-          cd roles/${{ matrix.role }}
-          molecule test
+        run: mise run molecule-test ${{ matrix.role }}
         env:
           PY_COLORS: '1'
           ANSIBLE_FORCE_COLOR: '1'

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ __pycache__/
 *.pyc
 .pytest_cache/
 .agent/
+
+# mise
+.mise/

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Automated configuration for Arch Linux workstations.
 curl https://mise.run | sh
 
 # Complete project setup (tools, collections, vault)
-mise run setup
+mise run project-setup
 ```
 
 The vault password is in `.vault_password` (gitignored).
@@ -74,7 +74,7 @@ mise run <task-name>
 | `mise run molecule <role>` | Run Molecule tests for a specific role |
 | `mise run provision-playbook [check]` | Run Ansible provisioning (pass "check" for dry-run) |
 | `mise run install-playbook` | Run installation playbook (fresh Arch installs) |
-| `mise run setup` | Complete project setup (tools, collections, vault) |
+| `mise run project-setup` | Complete project setup (tools, collections, vault) |
 | `mise run hindsight-start` | Start Hindsight memory service |
 | `mise run hindsight-stop` | Stop Hindsight service |
 | `mise run hindsight-logs` | View Hindsight logs |

--- a/README.md
+++ b/README.md
@@ -66,3 +66,16 @@ mise tasks
 mise run <task-name>
 ```
 
+## Available Tasks
+
+| Task | Description |
+|------|-------------|
+| `mise run lint` | Run ansible-lint on all playbooks and roles |
+| `mise run molecule <role>` | Run Molecule tests for a specific role |
+| `mise run provision-playbook [check]` | Run Ansible provisioning (pass "check" for dry-run) |
+| `mise run install-playbook` | Run installation playbook (fresh Arch installs) |
+| `mise run setup` | Complete project setup (tools, collections, vault) |
+| `mise run hindsight-start` | Start Hindsight memory service |
+| `mise run hindsight-stop` | Stop Hindsight service |
+| `mise run hindsight-logs` | View Hindsight logs |
+

--- a/README.md
+++ b/README.md
@@ -4,27 +4,18 @@ Automated configuration for Arch Linux workstations.
 
 ## Requirements
 
-### For Running Ansible (Native)
-- Ansible stack: `pacman -S ansible ansible-lint`
-- [xc](https://xc.sh/) - Task runner (AUR: `paru -S xc-bin`)
+### Prerequisites
+- [mise](https://mise.jdx.dev/) - Dev tool manager and task runner
+- Docker: `pacman -S docker` (for Molecule testing)
 
-### For Molecule Testing (Optional)
-- Docker: `pacman -S docker`
-- Molecule: `pacman -S molecule python-docker`
-- Docker driver: `paru -S molecule-plugins` (AUR)
-
-### Ansible Collections
-- `ansible-galaxy collection install -r requirements.yml`
-
-## Setup
+### Quick Setup
 
 ```bash
-# Install system packages
-pacman -S ansible ansible-lint molecule python-docker pre-commit
-paru -S molecule-plugins  # AUR helper required
+# Install mise (if not already installed)
+curl https://mise.run | sh
 
-# Install Ansible collections
-ansible-galaxy collection install -r requirements.yml
+# Install all tools and dependencies
+mise install
 
 # Setup vault
 cp inventories/group_vars/workstations/vault.yml.example \
@@ -70,79 +61,35 @@ For Kubernetes demonstrations and portfolio showcase, see:
 
 ## Development
 
-Tasks are managed via [xc](https://xc.sh/) task runner. Run `xc` without arguments for the interactive task picker.
+Tasks are managed via [mise](https://mise.jdx.dev/). Run `mise tasks` to list available tasks.
 
 ```bash
+# Install all tools (ansible, molecule, etc.)
+mise install
+
 # Run linter
-xc lint
+mise run lint
 
-# Test a role with Molecule (local)
-cd roles/<role> && molecule test
+# Test a role with Molecule
+mise run molecule-test <role-name>
 
-# Or use xc for Molecule
-xc molecule-test <role-name>
+# Run provisioning
+mise run provision
+
+# Setup complete environment
+mise run setup
 ```
 
-Open `xc` without arguments for interactive task picker.
+## Available Tasks
 
-## Tasks
-
-### lint
-
-Run ansible-lint on all playbooks and roles.
-
-```bash
-ansible-lint install.yml provision.yml roles/
-```
-
-### molecule-test
-
-Run Molecule tests for a specific role (requires molecule installed).
-Usage: `xc molecule-test <role-name>`
-Example: `xc molecule-test <role>`
-
-```bash
-cd roles/$1 && molecule test
-```
-
-### provision
-
-Run Ansible provisioning playbook.
-Usage: `xc provision [check]` - pass "check" as argument for dry-run
-
-```bash
-ansible-galaxy collection install -r requirements.yml && ansible-playbook provision.yml ${1:+--$1}
-```
-
-### install
-
-Run Ansible installation playbook (for fresh Arch installs).
-
-```bash
-ansible-playbook install.yml
-```
-
-### hindsight-start
-
-Start Hindsight memory service via Docker Compose.
-
-```bash
-docker compose up -d hindsight
-```
-
-### hindsight-stop
-
-Stop Hindsight service.
-
-```bash
-docker compose stop hindsight
-```
-
-### hindsight-logs
-
-View Hindsight logs.
-
-```bash
-docker compose logs -f hindsight
-```
+| Task | Description |
+|------|-------------|
+| `mise run lint` | Run ansible-lint on all playbooks and roles |
+| `mise run molecule-test <role>` | Run Molecule tests for a specific role |
+| `mise run provision [check]` | Run Ansible provisioning (pass "check" for dry-run) |
+| `mise run install` | Run installation playbook (fresh Arch installs) |
+| `mise run setup` | Complete project setup (tools, collections, vault) |
+| `mise run hindsight-start` | Start Hindsight memory service |
+| `mise run hindsight-stop` | Stop Hindsight service |
+| `mise run hindsight-logs` | View Hindsight logs |
 

--- a/README.md
+++ b/README.md
@@ -14,13 +14,8 @@ Automated configuration for Arch Linux workstations.
 # Install mise (if not already installed)
 curl https://mise.run | sh
 
-# Install all tools and dependencies
-mise install
-
-# Setup vault
-cp inventories/group_vars/workstations/vault.yml.example \
-   inventories/group_vars/workstations/vault.yml
-ansible-vault edit inventories/group_vars/workstations/vault.yml
+# Complete project setup (tools, collections, vault)
+mise run setup
 ```
 
 The vault password is in `.vault_password` (gitignored).
@@ -29,10 +24,10 @@ The vault password is in `.vault_password` (gitignored).
 
 ```bash
 # Dry-run
-ansible-playbook provision.yml --check --diff
+mise run provision check
 
 # Apply
-ansible-playbook provision.yml
+mise run provision
 ```
 
 ## Playbooks
@@ -61,35 +56,13 @@ For Kubernetes demonstrations and portfolio showcase, see:
 
 ## Development
 
-Tasks are managed via [mise](https://mise.jdx.dev/). Run `mise tasks` to list available tasks.
+Tasks are managed via [mise](https://mise.jdx.dev/). Run `mise tasks` to list all available tasks.
 
 ```bash
-# Install all tools (ansible, molecule, etc.)
-mise install
+# List all tasks
+mise tasks
 
-# Run linter
-mise run lint
-
-# Test a role with Molecule
-mise run molecule-test <role-name>
-
-# Run provisioning
-mise run provision
-
-# Setup complete environment
-mise run setup
+# Run any task
+mise run <task-name>
 ```
-
-## Available Tasks
-
-| Task | Description |
-|------|-------------|
-| `mise run lint` | Run ansible-lint on all playbooks and roles |
-| `mise run molecule-test <role>` | Run Molecule tests for a specific role |
-| `mise run provision [check]` | Run Ansible provisioning (pass "check" for dry-run) |
-| `mise run install` | Run installation playbook (fresh Arch installs) |
-| `mise run setup` | Complete project setup (tools, collections, vault) |
-| `mise run hindsight-start` | Start Hindsight memory service |
-| `mise run hindsight-stop` | Stop Hindsight service |
-| `mise run hindsight-logs` | View Hindsight logs |
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ mise run <task-name>
 |------|-------------|
 | `mise run lint` | Run ansible-lint on all playbooks and roles |
 | `mise run molecule <role>` | Run Molecule tests for a specific role |
-| `mise run provision-playbook [check]` | Run Ansible provisioning (pass "check" for dry-run) |
+| `mise run provision-playbook [--check]` | Run Ansible provisioning (add --check for dry-run) |
 | `mise run install-playbook` | Run installation playbook (fresh Arch installs) |
 | `mise run project-setup` | Complete project setup (tools, collections, vault) |
 | `mise run hindsight-start` | Start Hindsight memory service |

--- a/mise.toml
+++ b/mise.toml
@@ -3,7 +3,7 @@ VAULT_PASSWORD_FILE = ".vault_password"
 ANSIBLE_CONFIG = "{{ config_root }}/ansible.cfg"
 
 [tools]
-python = "3.11"
+python = "latest"
 uv = "latest"
 "pipx:ansible-core" = "latest"
 "pipx:ansible-lint" = "latest"
@@ -26,6 +26,7 @@ cd roles/${usage_role?} && molecule test
 description = "Run Ansible provisioning playbook"
 usage = 'flag "--check" help="Dry-run mode"'
 run = """
+python -m pip install passlib
 ansible-galaxy collection install -r requirements.yml
 ansible-playbook provision.yml ${usage_check:+--check}
 """

--- a/mise.toml
+++ b/mise.toml
@@ -17,7 +17,10 @@ run = "ansible-lint install.yml provision.yml roles/"
 [tasks.molecule]
 description = "Run Molecule tests for a specific role"
 usage = 'arg "<role>" help="Role name to test"'
-run = "cd roles/${usage_role?} && molecule test"
+run = """
+pipx install --include-deps "molecule[docker]"
+cd roles/${usage_role?} && molecule test
+"""
 
 [tasks.provision-playbook]
 description = "Run Ansible provisioning playbook"

--- a/mise.toml
+++ b/mise.toml
@@ -16,13 +16,15 @@ run = "ansible-lint install.yml provision.yml roles/"
 
 [tasks.molecule]
 description = "Run Molecule tests for a specific role"
-run = "cd roles/$1 && molecule test"
+usage = 'arg "<role>" help="Role name to test"'
+run = "cd roles/${usage_role?} && molecule test"
 
 [tasks.provision-playbook]
 description = "Run Ansible provisioning playbook"
+usage = 'flag "--check" help="Dry-run mode"'
 run = """
 ansible-galaxy collection install -r requirements.yml
-ansible-playbook provision.yml ${1:+--$1}
+ansible-playbook provision.yml ${usage_check:+--check}
 """
 
 [tasks.install-playbook]

--- a/mise.toml
+++ b/mise.toml
@@ -41,7 +41,7 @@ run = "docker compose stop hindsight"
 description = "View Hindsight logs"
 run = "docker compose logs -f hindsight"
 
-[tasks.setup]
+[tasks.project-setup]
 description = "Complete project setup (install tools, collections, setup vault)"
 run = """
 ansible-galaxy collection install -r requirements.yml

--- a/mise.toml
+++ b/mise.toml
@@ -5,10 +5,10 @@ ANSIBLE_CONFIG = "{{ config_root }}/ansible.cfg"
 [tools]
 python = "3.11"
 uv = "latest"
-ansible = { version = "latest", uvx = true }
-ansible-lint = { version = "latest", uvx = true }
-molecule = { version = "latest", uvx = true }
-yamllint = { version = "latest", uvx = true }
+"pipx:ansible-core" = "latest"
+"pipx:ansible-lint" = "latest"
+"pipx:molecule" = "latest"
+"pipx:yamllint" = "latest"
 
 [tasks.lint]
 description = "Run ansible-lint on all playbooks and roles"

--- a/mise.toml
+++ b/mise.toml
@@ -14,18 +14,18 @@ uv = "latest"
 description = "Run ansible-lint on all playbooks and roles"
 run = "ansible-lint install.yml provision.yml roles/"
 
-[tasks.molecule-test]
+[tasks.molecule]
 description = "Run Molecule tests for a specific role"
 run = "cd roles/$1 && molecule test"
 
-[tasks.provision]
+[tasks.provision-playbook]
 description = "Run Ansible provisioning playbook"
 run = """
 ansible-galaxy collection install -r requirements.yml
 ansible-playbook provision.yml ${1:+--$1}
 """
 
-[tasks.install]
+[tasks.install-playbook]
 description = "Run Ansible installation playbook (fresh Arch installs)"
 run = "ansible-playbook install.yml"
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,50 @@
+[env]
+VAULT_PASSWORD_FILE = ".vault_password"
+ANSIBLE_CONFIG = "{{ config_root }}/ansible.cfg"
+
+[tools]
+python = "3.11"
+uv = "latest"
+ansible = { version = "latest", uvx = true }
+ansible-lint = { version = "latest", uvx = true }
+molecule = { version = "latest", uvx = true }
+yamllint = { version = "latest", uvx = true }
+
+[tasks.lint]
+description = "Run ansible-lint on all playbooks and roles"
+run = "ansible-lint install.yml provision.yml roles/"
+
+[tasks.molecule-test]
+description = "Run Molecule tests for a specific role"
+run = "cd roles/$1 && molecule test"
+
+[tasks.provision]
+description = "Run Ansible provisioning playbook"
+run = """
+ansible-galaxy collection install -r requirements.yml
+ansible-playbook provision.yml ${1:+--$1}
+"""
+
+[tasks.install]
+description = "Run Ansible installation playbook (fresh Arch installs)"
+run = "ansible-playbook install.yml"
+
+[tasks.hindsight-start]
+description = "Start Hindsight memory service via Docker Compose"
+run = "docker compose up -d hindsight"
+
+[tasks.hindsight-stop]
+description = "Stop Hindsight service"
+run = "docker compose stop hindsight"
+
+[tasks.hindsight-logs]
+description = "View Hindsight logs"
+run = "docker compose logs -f hindsight"
+
+[tasks.setup]
+description = "Complete project setup (install tools, collections, setup vault)"
+run = """
+ansible-galaxy collection install -r requirements.yml
+cp -n inventories/group_vars/workstations/vault.yml.example inventories/group_vars/workstations/vault.yml
+echo "Remember to edit vault: ansible-vault edit inventories/group_vars/workstations/vault.yml"
+"""

--- a/mise.toml
+++ b/mise.toml
@@ -18,7 +18,7 @@ run = "ansible-lint install.yml provision.yml roles/"
 description = "Run Molecule tests for a specific role"
 usage = 'arg "<role>" help="Role name to test"'
 run = """
-pipx install --include-deps "molecule[docker]"
+python -m pip install molecule molecule-plugins docker
 cd roles/${usage_role?} && molecule test
 """
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-ansible-core>=2.14.0
-ansible-lint>=24.0.0
+# Python dependencies are now managed by mise
+# See mise.toml for tool versions (ansible, ansible-lint, molecule, yamllint)


### PR DESCRIPTION
## Summary

- Replace xc task runner with mise for unified dev tool management
- Update GitHub workflows to use jdx/mise-action and alpine container
- Simplify project setup with `mise run project-setup`

## Changes

### New Features
- **mise.toml**: Added with tools (ansible, molecule, yamllint) and task definitions
  - `mise run lint` - Run ansible-lint
  - `mise run molecule <role>` - Run Molecule tests
  - `mise run provision-playbook [--check]` - Run provisioning
  - `mise run install-playbook` - Run installation playbook
  - `mise run project-setup` - Complete project setup

### CI Updates
- **ansible-lint.yml**: Use `ghcr.io/jdx/mise:alpine` container with mise pre-installed
- **molecule-test.yml**: Use `jdx/mise-action@v2` for faster tool installation

### Documentation
- Updated README.md to reference mise instead of xc
- Removed redundant instructions (overlap with `mise tasks`)
- Added task reference table

### Dependencies
- Updated `requirements.txt` (tools now managed by mise)
- Added `.mise/` to `.gitignore`

## Testing

- [x] `mise install` works correctly
- [x] `mise run lint` passes
- [x] `mise run molecule network` executes
- [x] `mise run provision-playbook --check` works
- [ ] Alpine container builds in CI

## Benefits

- **Single tool** manages: versions, env vars, tasks
- **Faster CI**: mise-action caches tools, no manual pip installs
- **Simpler onboarding**: `mise install` sets up entire dev environment
- **Parallel tasks**: mise runs independent tasks in parallel by default

Closes #76