### PR TITLE
feat: setup opencode github integration

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,0 +1,33 @@
+name: opencode
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  opencode:
+    if: |
+      contains(github.event.comment.body, ' /oc') ||
+      startsWith(github.event.comment.body, '/oc') ||
+      contains(github.event.comment.body, ' /opencode') ||
+      startsWith(github.event.comment.body, '/opencode')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run opencode
+        uses: anomalyco/opencode/github@latest
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+        with:
+          model: opencode/big-pickle

--- a/provision.yml
+++ b/provision.yml
@@ -19,12 +19,12 @@
     - role: dev-workspace
     - role: bitwarden
     - role: obsidian
-    - role: brave
 
     # AUR-based roles
     - role: aur
     - role: spotify
     - role: vscodium
+    - role: brave
 
     # whimsyforge only
     - role: qemu


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for opencode integration (`.github/workflows/opencode.yml`)
- Configure permissions to allow opencode to create PRs but not merge them
- Triggers on issue/PR comments containing `/oc` or `/opencode`

## Changes
- **New file**: `.github/workflows/opencode.yml`
  - Uses `anomalyco/opencode/github@latest` action
  - Model: `opencode/big-pickle`
  - Permissions: `contents: write`, `pull-requests: write`, `issues: write`, `id-token: write`
  - File ends with proper newline

- **Modified**: `provision.yml`
  - Reorder `brave` role placement

## Remaining Setup (Post-Merge)
1. Install opencode-agent GitHub App: https://github.com/apps/opencode-agent
2. Add `OPENCODE_API_KEY` secret in repo Settings → Secrets and variables → Actions

## Testing
After setup is complete, test by commenting `/oc hello` on any issue or PR.

Closes # (if applicable)