### PR TITLE
fix(provision): handle check mode and add molecule galaxy namespaces

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -42,23 +42,31 @@ ansible-playbook provision-vm.yml ${usage_check:+--check}
 description = "Run Ansible installation playbook (fresh Arch installs)"
 run = "ansible-playbook install.yml"
 
+[tasks.hindsight-kubeconfig]
+description = "Ensure local kubeconfig points to the k3d dev-cluster"
+hide = true
+run = "k3d kubeconfig merge dev-cluster -d --kubeconfig-switch-context=false 2>/dev/null; mkdir -p ~/.kube && k3d kubeconfig get dev-cluster > ~/.kube/config 2>/dev/null || true"
+
 [tasks.hindsight-start]
 description = "Start Hindsight memory service via Kubernetes"
+depends = ["hindsight-kubeconfig"]
 run = "kubectl scale deployment/hindsight --replicas=1 -n hindsight"
 
 [tasks.hindsight-stop]
 description = "Stop Hindsight service"
+depends = ["hindsight-kubeconfig"]
 run = "kubectl scale deployment/hindsight --replicas=0 -n hindsight"
 
 [tasks.hindsight-logs]
 description = "View Hindsight logs"
+depends = ["hindsight-kubeconfig"]
 run = "kubectl logs -f deployment/hindsight -n hindsight"
 
 [tasks.project-setup]
 description = "Complete project setup (install tools, collections, setup vault)"
 run = """
 ansible-galaxy collection install -r requirements.yml
-cp -n inventories/group_vars/workstations/vault.yml.example inventories/group_vars/all/vault.yml
+cp -n inventories/group_vars/all/vault.yml.example inventories/group_vars/all/vault.yml
 echo "Remember to edit vault: ansible-vault edit inventories/group_vars/all/vault.yml"
 """
 

--- a/roles/dev-workspace/tasks/main.yml
+++ b/roles/dev-workspace/tasks/main.yml
@@ -16,6 +16,7 @@
     gh repo list {{ workspace_org }} --json name,sshUrl,isArchived --limit 100
   register: gh_repo_list
   changed_when: false
+  check_mode: false
   when: workspace_dynamic_clone
   become: true
   become_user: "{{ user_name }}"

--- a/roles/kubernetes/meta/main.yml
+++ b/roles/kubernetes/meta/main.yml
@@ -1,5 +1,6 @@
 ---
 galaxy_info:
+  namespace: gnome_network
   role_name: kubernetes
   author: Gnome Network Ansible project
   description: Sets up a local k3d Kubernetes cluster and deploys Hindsight

--- a/roles/kubernetes/tasks/create_cluster.yml
+++ b/roles/kubernetes/tasks/create_cluster.yml
@@ -4,13 +4,20 @@
   register: k3d_cluster_list
   changed_when: false
   failed_when: false
+  check_mode: false
   tags: [kubernetes]
 
 - name: Parse cluster list
   ansible.builtin.set_fact:
-    k3d_clusters: "{{ k3d_cluster_list.stdout | from_json | default([], true) }}"
+    k3d_clusters: "{{ k3d_cluster_list.stdout | default('[]') | from_json | default([], true) }}"
   changed_when: false
-  when: k3d_cluster_list.rc == 0
+  when: k3d_cluster_list.stdout | default('') | length > 0
+  tags: [kubernetes]
+
+- name: Fallback to empty cluster list
+  ansible.builtin.set_fact:
+    k3d_clusters: []
+  when: k3d_cluster_list.stdout | default('') | length == 0
   tags: [kubernetes]
 
 - name: Check if target cluster exists

--- a/roles/vscodium/meta/main.yml
+++ b/roles/vscodium/meta/main.yml
@@ -1,3 +1,18 @@
 ---
+galaxy_info:
+  namespace: gnome_network
+  role_name: vscodium
+  author: Gnome Network Ansible project
+  description: Installs VSCodium editor
+  license: MIT
+  min_ansible_version: "2.9"
+  platforms:
+    - name: ArchLinux
+      versions:
+        - all
+  galaxy_tags:
+    - vscodium
+    - editor
+
 dependencies:
   - role: aur


### PR DESCRIPTION
## Description

Fixes three categories of issues discovered during full mise task testing:

### Check mode fixes
- **k3d cluster discovery** — Added `check_mode: false` to the k3d cluster list command so it runs during `--check` dry runs. Added empty stdout fallback to avoid `from_json` parse errors.
- **gh repo list** — Added `check_mode: false` so the command executes during `--check` runs, preventing the static fallback clone task from running with wrong data.

### Molecule galaxy namespace fixes
- Added `namespace: gnome_network` and `galaxy_info` blocks to `vscodium` and `kubernetes` role meta files. Molecule requires fully qualified role names for guest OS testing.

### Mise task fixes
- Fixed vault example copy path in `project-setup` (`workstations/` → `all/`)
- Added `hindsight-kubeconfig` hidden task to merge local k3d dev-cluster kubeconfig into `~/.kube/config`, with hindsight tasks depending on it

## Commits
- fix(provision): handle ansible check mode in k3d and gh discovery tasks
- fix(molecule): add galaxy namespace to role meta files
- fix(mise): correct vault path and add hindsight kubeconfig setup